### PR TITLE
Add example of menu navbar settings to theme.md

### DIFF
--- a/exampleSite/content/en/configuration/theme.md
+++ b/exampleSite/content/en/configuration/theme.md
@@ -86,7 +86,26 @@ menu:
 ---
 ```
 
+### Navbar settings in config
 If you try to put entry that aren't attached to a piece of content, or you want to organize your navbar into a single file, checkout [Add Non-content Entries to a Menu](https://gohugo.io/content-management/menus#add-non-content-entries-to-a-menu) and set these values in your toml settings file.
+
+```
+menu:
+  navbar:
+  - identifier: about
+    name: about
+    title: about
+    url: /about/
+    weight: 100
+  - identifier: series
+    name: series
+    url: /series/
+    weight: -100
+  - identifier: categories
+    name: categories
+    url: /categories/
+    weight: 80
+```
 
 ## External Library
 

--- a/exampleSite/content/en/configuration/theme.md
+++ b/exampleSite/content/en/configuration/theme.md
@@ -89,7 +89,28 @@ menu:
 ### Navbar settings in config
 If you try to put entry that aren't attached to a piece of content, or you want to organize your navbar into a single file, checkout [Add Non-content Entries to a Menu](https://gohugo.io/content-management/menus#add-non-content-entries-to-a-menu) and set these values in your toml settings file.
 
+```toml
+[[menu.navbar]]
+identifier = "about"
+name = "about"
+title = "about"
+url = "/about/"
+weight = 100
+
+[[menu.navbar]]
+identifier = "series"
+name = "series"
+url = "/series/"
+weight = -100
+
+[[menu.navbar]]
+identifier = "categories"
+name = "categories"
+url = "/categories/"
+weight = 80
 ```
+
+```yaml
 menu:
   navbar:
   - identifier: about

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -9,7 +9,7 @@
 {{ if .Site.Taxonomies.tags }}
     <div class="my-8">
         <h1 class="text-xl font-semibold my-3">{{ i18n "tags" }}</h1>
-        {{- partial "tag-cloud.html" .Site.Taxonomies.tags.Alphabetical -}}
+        {{- partial "terms-cloud.html" .Site.Taxonomies.tags.Alphabetical -}}
     </div>
 {{ end }}
 


### PR DESCRIPTION
Existing hugo docs show menu settings as [[menu.main]]. This theme wants to use `[[menu.navbar]] instead.

updated docs with examples of config.yaml and config.toml settings for navbar because it took me a while to figure it out!

(I apologize for the messy pull requests. I'm new to this!)