### PR TITLE
TOC collapse fix

### DIFF
--- a/assets/scss/base.scss
+++ b/assets/scss/base.scss
@@ -62,11 +62,11 @@ mark {
 }
 
 details > summary {
-  cursor: zoom-in;
+  cursor: pointer;
 }
 
 details[open] > summary {
-  cursor: zoom-out;
+  cursor: pointer;
 }
 
 .content-margin {


### PR DESCRIPTION
Fixes #25. Makes a cursor to display a pointer instead of magnifying glass.