### PR TITLE
Example site: fix error when previewing with latest hugo version 0.146.7

### DIFF
--- a/layouts/partials/terms-cloud.html
+++ b/layouts/partials/terms-cloud.html
@@ -1,13 +1,13 @@
 {{- $terms := .terms -}}
 {{- $sortby := .sortby | default "count" -}}
 {{- $order := .order | default "asc" -}}
-{{- if eq $sortby "count" -}}
-    {{- $terms = sort $terms "Count" $order -}}
-{{- else if eq $sortby "alphabetical" -}}
-    {{- $terms = sort $terms "Page.Title" $order -}}
-{{- end -}}
+{{- with $terms -}}
+    {{- if eq $sortby "count" -}}
+        {{- $terms = sort . "Count" $order -}}
+    {{- else if eq $sortby "alphabetical" -}}
+        {{- $terms = sort . "Page.Title" $order -}}
+    {{- end -}}
 
-{{ if $terms }}
     {{ $fontSmall := 0.875 }}
     {{ $fontBig := 1.6 }}
     {{ $fontSpread := sub $fontBig $fontSmall }}


### PR DESCRIPTION
When previewing example site with latest hugo version 0.146.7, an error is thrown:

```
ERROR render of "/categories/syntax" failed: "/home/andreas/hugo-theme-monochrome/layouts/_default/taxonomy.html:6:12": execute of template failed: template: _default/taxonomy.html:6:12: executing "content" at <partial "terms-cloud.html" (dict "terms" .Data.Terms "sortby" "count" "order" "desc")>: error calling partial: "/home/andreas/hugo-theme-monochrome/layouts/partials/terms-cloud.html:5:17": execute of template failed: template: _partials/terms-cloud.html:5:17: executing "_partials/terms-cloud.html" at <sort $terms "Count" $order>: error calling sort: sequence must be provided
```

This PR fixes that issue.