### PR TITLE
fix: move author config under Params dict

### DIFF
--- a/exampleSite/content/en/configuration/theme.md
+++ b/exampleSite/content/en/configuration/theme.md
@@ -245,8 +245,10 @@ Enable Prism.js
 ### Author
 
 ```toml
-[params]
-author = "kaiiiz" # default: no author `meta` tag
+# default: no author `meta` tag
+[params.author]
+name = "kaiiiz"
+email = "ukaizheng@gmail.com"
 ```
 
 ### Open Graph

--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -20,7 +20,7 @@
     <meta name="keywords" content="{{ delimit . "," }}" />
     {{ end }}
 
-    {{ with (.Store.Get "params").author }}
+    {{ with (.Store.Get "params").author_name }}
     <meta name="author" content="{{ . }}" />
     {{ end }}
 

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -5,7 +5,7 @@
 {{ .Store.SetInMap "params" "navbar_width" (.Params.navbar_width | default .Site.Params.navbar_width | default "wide") }}
 {{ .Store.SetInMap "params" "navbar_show_all_languages" (.Params.navbar_show_all_languages | default .Site.Params.navbar_show_all_languages | default true) }}
 {{ .Store.SetInMap "params" "hide_navbar_on_scroll" (.Params.hide_navbar_on_scroll | default .Site.Params.hide_navbar_on_scroll | default true) }}
-{{ .Store.SetInMap "params" "author" (.Params.author | default .Site.Params.author) }}
+{{ .Store.SetInMap "params" "author_name" (.Params.author.name | default .Site.Params.author.name) }}
 {{ .Store.SetInMap "params" "enable_open_graph" (.Params.open_graph | default .Site.Params.enable_open_graph | default true) }}
 {{ .Store.SetInMap "params" "enable_twitter_cards" (.Params.twitter_cards | default .Site.Params.enable_twitter_cards | default true) }}
 {{ .Store.SetInMap "params" "enable_toc" (.Params.toc | default .Site.Params.enable_toc | default true) }}

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -17,9 +17,9 @@
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
-    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Params.Author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.Author.email }}
+    <webMaster>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{- with .OutputFormats.Get "RSS" -}}
@@ -30,7 +30,7 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      {{ with .Site.Params.Author.email }}<author>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | html }}</description>
     </item>


### PR DESCRIPTION
This fixes a bug on newer hugo versions (specifically [v0.156.0](https://github.com/gohugoio/hugo/releases/tag/v0.156.0) and later) where the RSS feed does not build because `.Site.Author` should now be set and used as `.Site.Params.Author`.

Fixes #83