### PR TITLE
fix: patch to fix minor bug when user scrolls before moving mouse

### DIFF
--- a/assets/js/hide-navbar-on-scroll.js
+++ b/assets/js/hide-navbar-on-scroll.js
@@ -5,6 +5,7 @@ const threshold = 100;
 let lastScrollY = window.scrollY;
 let isScrollHide = false;
 let isInDropdownMenu = false;
+let isMouseNearTop = true;
 let headerHeight = (header !== undefined) ? header.offsetHeight : 0;
 let hideTimer = null;
 


### PR DESCRIPTION
There's a minor bug where since an implicit global var `isMouseNearTop` is first defined when the mouse is moved, when the user just scrolls without moving their mouse, `updateNavbarVisibility` attempts to read `isMouseNearTop` which is not defined yet and errors out.

<img width="922" height="346" alt="image" src="https://github.com/user-attachments/assets/0db3e58b-e15d-4e78-b6d2-3cb79276d290" />