### PR TITLE
fix: .Site.LanguageCode deprecation

### DIFF
--- a/layouts/_partials/resources/js.html
+++ b/layouts/_partials/resources/js.html
@@ -79,7 +79,7 @@
 {{ end }}
 
 {{ if (.Store.Get "params").enable_site_search }}
-    {{ $target_path := printf "js/search-%s.js" .Site.LanguageCode }}
+    {{ $target_path := printf "js/search-%s.js" .Site.Language.Locale }}
     {{ $index_url := "index.json" | absLangURL }}
     {{ $build_opts := dict "targetPath" $target_path "params" (dict "index_url" $index_url) }}
     {{ $search_js := resources.Get "js/search.js" | js.Build $build_opts }}

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -21,7 +21,7 @@
 {{ partial "states.html" . }}
 
 <!DOCTYPE html>
-<html lang='{{ .Site.LanguageCode }}'>
+<html lang='{{ .Site.Language.Locale }}'>
     {{- partial "head.html" . -}}
     <body>
         {{- partial "header.html" . -}}

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -16,7 +16,7 @@
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.Language.Locale }}
     <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
     <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
     <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}


### PR DESCRIPTION
.Site.LanguageCode is deprecated and hugo raise a warning when started.
See https://gohugo.io/configuration/languages/#languagecode

Warning : 
`WARN  deprecated: .Site.LanguageCode was deprecated in Hugo v0.158.0 and will be removed in a future release. Use .Site.Language.Locale instead.`